### PR TITLE
fix typos and tool names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,8 @@ If applicable, add screenshots to help explain your problem.
 
 **Used ContextQuickie features:**
  - Beyond Compare
- - Tortoise SVN
- - Tortoise Git
+ - TortoiseSVN
+ - TortoiseGit
 
 **Additional context**
 Add any other context about the problem here.

--- a/ContextQuickie.TeamProvider/plugin.xml
+++ b/ContextQuickie.TeamProvider/plugin.xml
@@ -16,7 +16,7 @@
             class="contextquickie.teamprovider.svn.ConfigurationWizard"
             icon="icons/Tortoise.ico"
             id="contextquickie.teamprovider.svn.ConfigurationWizard"
-            name="ContextQuickie (via Tortoise SVN)">
+            name="ContextQuickie (via TortoiseSVN)">
       </wizard>
    </extension>
 </plugin>

--- a/ContextQuickie/src/contextquickie/preferences/ContextQuickie.java
+++ b/ContextQuickie/src/contextquickie/preferences/ContextQuickie.java
@@ -191,10 +191,10 @@ public class ContextQuickie extends FieldEditorPreferencePage implements IWorkbe
       final TortoisePreferenceConstants preferenceConstants)
   {
     FieldEditor dependentFieldEditor;
-    final String showTortoise = "Show Tortoise ";
+    final String showTortoise = "Show Tortoise";
     
     final ArrayList<FieldEditor> dependentFields = new ArrayList<FieldEditor>();
-    final BooleanFieldEditor featureEnabledEditor = new BooleanFieldEditor(preferenceConstants.getEnabled(), "Enable Tortoise " + name,
+    final BooleanFieldEditor featureEnabledEditor = new BooleanFieldEditor(preferenceConstants.getEnabled(), "Enable Tortoise" + name,
         getFieldEditorParent());
     addField(featureEnabledEditor);
 
@@ -245,7 +245,7 @@ public class ContextQuickie extends FieldEditorPreferencePage implements IWorkbe
     }
     ComboFieldEditor comboFieldEditor = new ComboFieldEditor(
         preferenceConstants.getUsedVersion(), 
-        "Select Tortoise " + name + " version", supportedVersions, getFieldEditorParent());
+        "Select Tortoise" + name + " version", supportedVersions, getFieldEditorParent());
     addField(comboFieldEditor);
     dependentFields.add(comboFieldEditor);
   }

--- a/ContextQuickie/src/contextquickie/preferences/PreferenceConstants.java
+++ b/ContextQuickie/src/contextquickie/preferences/PreferenceConstants.java
@@ -34,17 +34,17 @@ public final class PreferenceConstants
   private static final String[] SupportedTortoiseSvnVersions = new String[] { "1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14" };
 
   /**
-   * Configuration items for the configuration of Tortoise SVN.
+   * Configuration items for the configuration of TortoiseSVN.
    */
   public static final TortoisePreferenceConstants TORTOISE_SVN = new TortoisePreferenceConstants("TortoiseSvn", ".svn", "TortoiseSVN", SupportedTortoiseSvnVersions);
 
   /**
-   * Configuration items for the configuration of Tortoise Git.
+   * Configuration items for the configuration of TortoiseGit.
    */
   public static final TortoisePreferenceConstants TORTOISE_GIT = new TortoisePreferenceConstants("TortoiseGit", ".git", SupportedTortoiseGitVersions);
 
   /**
-   * Configuration items for the configuration of Tortoise Hg.
+   * Configuration items for the configuration of TortoiseHg.
    */
   public static final TortoisePreferenceConstants TORTOISE_HG = new TortoisePreferenceConstants("TortoiseHg", ".hg", SupportedTortoiseHgVersions);
 

--- a/ContextQuickie/src/contextquickie/preferences/PreferenceInitializer.java
+++ b/ContextQuickie/src/contextquickie/preferences/PreferenceInitializer.java
@@ -105,7 +105,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer
   private void getStoreConfigurationItemFromRegistry(final IPreferenceStore store, final String registryLocation, final String registryKey,
       final String defaultValue, final String configurationItem)
   {
-    // Try to retrieve the path to the Tortoise SVN executable.
+    // Try to retrieve the path to the TortoiseSVN executable.
     String registryValue = new Registry().readStringValue(registryLocation, registryKey, defaultValue);
     store.setDefault(configurationItem, registryValue);
   }

--- a/ContextQuickie/src/contextquickie/tortoise/TortoiseMenuConstants.java
+++ b/ContextQuickie/src/contextquickie/tortoise/TortoiseMenuConstants.java
@@ -3,7 +3,7 @@ package contextquickie.tortoise;
 /**
  * @author ContextQuickie
  *
- *         Constants which are used in the Tortoise SVN menu.
+ *         Constants which are used in the TortoiseSVN menu.
  */
 public final class TortoiseMenuConstants
 {

--- a/ContextQuickie/src/contextquickie/tortoise/git/MenuIdentifier.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/MenuIdentifier.java
@@ -3,7 +3,7 @@ package contextquickie.tortoise.git;
 /**
  * @author ContextQuickie
  *
- *         Menu identifiers for Tortoise Git.
+ *         Menu identifiers for TortoiseGit.
  */
 public class MenuIdentifier
 {

--- a/ContextQuickie/src/contextquickie/tortoise/git/MenuTextIdentifier.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/MenuTextIdentifier.java
@@ -3,7 +3,7 @@ package contextquickie.tortoise.git;
 /**
  * @author ContextQuickie
  *
- *         Menu text identifiers for Tortoise Git.
+ *         Menu text identifiers for TortoiseGit.
  */
 @SuppressWarnings("javadoc")
 public class MenuTextIdentifier

--- a/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitCommand.java
@@ -6,7 +6,7 @@ import contextquickie.tortoise.AbstractTortoiseCommand;
 /**
  * @author ContextQuickie
  * 
- *         Class which executes all Tortoise Git commands based on the passed
+ *         Class which executes all TortoiseGit commands based on the passed
  *         parameters.
  */
 public class TortoiseGitCommand extends AbstractTortoiseCommand

--- a/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitDiffLaterCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitDiffLaterCommand.java
@@ -4,7 +4,7 @@ import contextquickie.preferences.PreferenceConstants;
 import contextquickie.tortoise.AbstractTortoiseDiffLaterCommand;
 
 /**
- * Handler for the Tortoise Git "diff later" command.
+ * Handler for the TortoiseGit "diff later" command.
  */
 public class TortoiseGitDiffLaterCommand extends AbstractTortoiseDiffLaterCommand
 {

--- a/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitDiffTwoFilesCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitDiffTwoFilesCommand.java
@@ -6,7 +6,7 @@ import contextquickie.tortoise.AbstractTortoiseDiffTwoFilesCommand;
 /**
  * @author ContextQuickie
  *
- *     Class for execute a Tortoise Git diff command with two selected files.
+ *     Class for execute a TortoiseGit diff command with two selected files.
  */
 public class TortoiseGitDiffTwoFilesCommand extends AbstractTortoiseDiffTwoFilesCommand
 {

--- a/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitMenuBuilder.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitMenuBuilder.java
@@ -26,7 +26,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 /**
  * @author ContextQuickie
  *
- *         Menu configuration for Tortoise Git.
+ *         Menu configuration for TortoiseGit.
  */
 public class TortoiseGitMenuBuilder extends AbstractTortoiseMenuBuilder implements BiPredicate<TortoiseMenuEntry, TortoiseEnvironment>
 {
@@ -273,17 +273,17 @@ public class TortoiseGitMenuBuilder extends AbstractTortoiseMenuBuilder implemen
   private static final long MENUABOUT = 0x8000000000000000L;
   
   /**
-   * The value of ContextMenuExtEntriesLow in the registry settings of Tortoise Git.
+   * The value of ContextMenuExtEntriesLow in the registry settings of TortoiseGit.
    */
   private long ContextMenuExtEntriesLow;
   
   /**
-   * The value of ContextMenuExtEntriesHigh in the registry settings of Tortoise Git.
+   * The value of ContextMenuExtEntriesHigh in the registry settings of TortoiseGit.
    */
   private long ContextMenuExtEntriesHigh;
   
   /**
-   * Tortoise Git menu configuration.
+   * TortoiseGit menu configuration.
    */
   private static final List<TortoiseMenuEntry> entries = new ArrayList<TortoiseMenuEntry>();
 
@@ -293,7 +293,7 @@ public class TortoiseGitMenuBuilder extends AbstractTortoiseMenuBuilder implemen
   private static final Translation translation;
   
   /**
-   * The path to the icons based on the used Tortoise Git version.
+   * The path to the icons based on the used TortoiseGit version.
    */
   private static final String iconPath;
   
@@ -438,7 +438,7 @@ public class TortoiseGitMenuBuilder extends AbstractTortoiseMenuBuilder implemen
         .setMenuId(MENUDIFFTWO)
         .setIconPath(menuCompareIconPath)
         .setCommand("diffcommits")
-        .setMaxItemsCount(0)); // Disabled. Didn't find any hint in Tortoise Git source how to handle this entry.
+        .setMaxItemsCount(0)); // Disabled. Didn't find any hint in TortoiseGit source how to handle this entry.
 
     entries.add(new TortoiseMenuEntry()
         .setLabel(translation.getTranslatedString(MenuTextIdentifier.IDS_MENULOG, "Show log"))
@@ -817,7 +817,7 @@ public class TortoiseGitMenuBuilder extends AbstractTortoiseMenuBuilder implemen
         .setMenuId(MENUCLIPPASTE)
         .setIconPath(iconPath + "menusendmail.ico")
         .setCommand("settings")
-        .setMaxItemsCount(0)); // TODO: Disabled, also not supported by Tortoise Git
+        .setMaxItemsCount(0)); // TODO: Disabled, also not supported by TortoiseGit
 
     // Separator
     entries.add(new TortoiseMenuSeperator());

--- a/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitMergeCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/TortoiseGitMergeCommand.java
@@ -5,7 +5,7 @@ import contextquickie.tortoise.AbstractTortoiseMergeCommand;
 
 /**
  * @author ContextQuickie
- *     Class for execute a Tortoise Git merge command.
+ *     Class for execute a TortoiseGit merge command.
  */
 public class TortoiseGitMergeCommand extends AbstractTortoiseMergeCommand
 {

--- a/ContextQuickie/src/contextquickie/tortoise/git/package-info.java
+++ b/ContextQuickie/src/contextquickie/tortoise/git/package-info.java
@@ -1,6 +1,6 @@
 
 /**
- * This package provides all classes used for all Tortoise Git based plug-ins.
+ * This package provides all classes used for all TortoiseGit based plug-ins.
  */
 /**
  * @author ContextQuickie

--- a/ContextQuickie/src/contextquickie/tortoise/hg/TortoiseHgCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/hg/TortoiseHgCommand.java
@@ -19,7 +19,7 @@ import contextquickie.tortoise.TortoiseMenuConstants;
 /**
  * @author ContextQuickie
  * 
- *         Class which executes all Tortoise Hg commands based on the passed
+ *         Class which executes all TortoiseHg commands based on the passed
  *         parameters.
  */
 public class TortoiseHgCommand extends AbstractTortoiseCommand

--- a/ContextQuickie/src/contextquickie/tortoise/hg/TortoiseHgDiffTwoFilesCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/hg/TortoiseHgDiffTwoFilesCommand.java
@@ -5,7 +5,7 @@ import contextquickie.tortoise.AbstractTortoiseDiffTwoFilesCommand;
 
 /**
  * @author ContextQuickie
- *     Class for execute a Tortoise Hg diff command with two selected files.
+ *     Class for execute a TortoiseHg diff command with two selected files.
  */
 public class TortoiseHgDiffTwoFilesCommand extends AbstractTortoiseDiffTwoFilesCommand
 {

--- a/ContextQuickie/src/contextquickie/tortoise/hg/TortoiseHgMenuBuilder.java
+++ b/ContextQuickie/src/contextquickie/tortoise/hg/TortoiseHgMenuBuilder.java
@@ -19,12 +19,12 @@ import contextquickie.windows.Registry;
 public class TortoiseHgMenuBuilder extends AbstractTortoiseMenuBuilder
 {
   /**
-   * Tortoise Hg menu configuration.
+   * TortoiseHg menu configuration.
    */
   private static final List<TortoiseMenuEntry> entries = new ArrayList<TortoiseMenuEntry>();
   
   /**
-   * The path to the icons based on the used Tortoise Hg version.
+   * The path to the icons based on the used TortoiseHg version.
    */
   private static final String iconPath = "TortoiseHg/5.5/";
   

--- a/ContextQuickie/src/contextquickie/tortoise/hg/package-info.java
+++ b/ContextQuickie/src/contextquickie/tortoise/hg/package-info.java
@@ -1,6 +1,6 @@
 
 /**
- * This package provides all classes used for all Tortoise Hg based plug-ins.
+ * This package provides all classes used for all TortoiseHg based plug-ins.
  */
 /**
  * @author ContextQuickie

--- a/ContextQuickie/src/contextquickie/tortoise/svn/MenuTextIdentifier.java
+++ b/ContextQuickie/src/contextquickie/tortoise/svn/MenuTextIdentifier.java
@@ -2,7 +2,7 @@ package contextquickie.tortoise.svn;
 /**
  * @author ContextQuickie
  *
- *         Menu text identifiers for Tortoise SVN.
+ *         Menu text identifiers for TortoiseSVN.
  */
 @SuppressWarnings("javadoc")
 public class MenuTextIdentifier

--- a/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnCommand.java
@@ -6,7 +6,7 @@ import contextquickie.tortoise.AbstractTortoiseCommand;
 /**
  * @author ContextQuickie
  * 
- *         Class which executes all Tortoise SVN commands based on the passed
+ *         Class which executes all TortoiseSVN commands based on the passed
  *         parameters.
  */
 public class TortoiseSvnCommand extends AbstractTortoiseCommand

--- a/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnDiffTwoFilesCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnDiffTwoFilesCommand.java
@@ -5,7 +5,7 @@ import contextquickie.tortoise.AbstractTortoiseDiffTwoFilesCommand;
 
 /**
  * @author ContextQuickie
- *     Class for execute a Tortoise SVN diff command with two selected files.
+ *     Class for execute a TortoiseSVN diff command with two selected files.
  */
 public class TortoiseSvnDiffTwoFilesCommand extends AbstractTortoiseDiffTwoFilesCommand
 {

--- a/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnMenuBuilder.java
+++ b/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnMenuBuilder.java
@@ -16,7 +16,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 /**
  * @author ContextQuickie
  *
- *         Menu configuration for Tortoise SVN.
+ *         Menu configuration for TortoiseSVN.
  */
 public class TortoiseSvnMenuBuilder extends AbstractTortoiseMenuBuilder
 {
@@ -238,7 +238,7 @@ public class TortoiseSvnMenuBuilder extends AbstractTortoiseMenuBuilder
   private static final long MENUUNSHELVE = 0x0000020000000000L;
 
   /**
-   * Tortoise SVN menu configuration.
+   * TortoiseSVN menu configuration.
    */
   private static List<TortoiseMenuEntry> entries = new ArrayList<TortoiseMenuEntry>();
 
@@ -248,7 +248,7 @@ public class TortoiseSvnMenuBuilder extends AbstractTortoiseMenuBuilder
   private static final Translation translation;
 
   /**
-   * The path to the icons based on the used Tortoise SVN version.
+   * The path to the icons based on the used TortoiseSVN version.
    */
   private static final String iconPath;
 

--- a/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnMergeCommand.java
+++ b/ContextQuickie/src/contextquickie/tortoise/svn/TortoiseSvnMergeCommand.java
@@ -5,7 +5,7 @@ import contextquickie.tortoise.AbstractTortoiseMergeCommand;
 
 /**
  * @author ContextQuickie
- *     Class for execute a Tortoise SVN merge command.
+ *     Class for execute a TortoiseSVN merge command.
  */
 public final class TortoiseSvnMergeCommand extends AbstractTortoiseMergeCommand
 {

--- a/ContextQuickie/src/contextquickie/tortoise/svn/package-info.java
+++ b/ContextQuickie/src/contextquickie/tortoise/svn/package-info.java
@@ -1,6 +1,6 @@
 
 /**
- * This package provides all classes used for all Tortoise SVN based plug-ins.
+ * This package provides all classes used for all TortoiseSVN based plug-ins.
  */
 /**
  * @author ContextQuickie

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ContextQuickie
-An eclipse add-on which extends the context menu for accessing various windows tools like Beyond Compare, Tortoise SVN or Tortoise Git.
+An eclipse add-on which extends the context menu for accessing various windows tools like Beyond Compare, TortoiseSVN or TortoiseGit.
 Important note: The update site URL has changed:
 * Releases: http://contextquickie.github.io/ContextQuickie/Releases
 * Development: http://contextquickie.github.io/ContextQuickie/Development
@@ -9,35 +9,35 @@ The wiki provides further information:
 * [Usage](https://github.com/ContextQuickie/ContextQuickie/wiki/Usage)
 
 # ContextQuickie.TeamProvider
-This plugin provides a Tortiose SVN based team provider to eclise which forwards the following eclipse operations to the working copy:
+This plugin provides a TortoiseSVN based team provider to eclipse which forwards the following eclipse operations to the working copy:
 * Adding new files
 * Copying files
 * Moving files
 
-Starting with version 0.4.0, it is possible to export and import projects sets which can be e.g. used for automatic deployment with Eclipse Oomph. A detailled description of the prject set file format can be found [here](https://github.com/ContextQuickie/ContextQuickie/wiki/Team-Project-Set-File-Format).
+Starting with version 0.4.0, it is possible to export and import projects sets which can be e.g. used for automatic deployment with Eclipse Oomph. A detailed description of the project set file format can be found [here](https://github.com/ContextQuickie/ContextQuickie/wiki/Team-Project-Set-File-Format).
 
-To use ContextQuickie.Teamprovider one of the following Tortoise SVN versions must be installed:
+To use ContextQuickie.Teamprovider one of the following TortoiseSVN versions must be installed:
 * 1.9.7/1.9.8
 * 1.10.1/1.10.2/1.10.3
 * 1.11.0/1.11.1
 
 Remarks:
-* Torotise SVN versions 1.8.x and below cannot be used because the JavaHL libraries of this versions don't provide the required APIs.
-* If you're using a 64bit version of eclipse you also need the 64bit version of Tortoise SVN. Same for the 32bit version. Mixing architecutres doesn't work.
+* TortoiseSVN versions 1.8.x and below cannot be used because the JavaHL libraries of this versions don't provide the required APIs.
+* If you're using a 64bit version of eclipse you also need the 64bit version of TortoiseSVN. Same for the 32bit version. Mixing architectures doesn't work.
 
 # Screenshots
 Compare two files selected in a navigator view with Beyond Compare:
 
 ![Compare two files selected in a navigator view with Beyond Compare](https://github.com/ContextQuickie/ContextQuickie/blob/master/Images/CompareTwoFiles.png)
 
-Tortoise Git and Beyond Compare in a navigator view:
+TortoiseGit and Beyond Compare in a navigator view:
 
-![Tortoise Git and Beyond Compare in a navigator view](https://github.com/ContextQuickie/ContextQuickie/blob/master/Images/TortoiseGitAndBeyondCompare.png)
+![TortoiseGit and Beyond Compare in a navigator view](https://github.com/ContextQuickie/ContextQuickie/blob/master/Images/TortoiseGitAndBeyondCompare.png)
 
-Tortoise SVN and Beyond Compare in a navigator view:
+TortoiseSVN and Beyond Compare in a navigator view:
 
-![Tortoise SVN and Beyond Compare in a navigator view](https://github.com/ContextQuickie/ContextQuickie/blob/master/Images/TortoiseSvnAndBeyondCompare.png)
+![TortoiseSVN and Beyond Compare in a navigator view](https://github.com/ContextQuickie/ContextQuickie/blob/master/Images/TortoiseSvnAndBeyondCompare.png)
 
-Tortoise SVN and Beyond Compare in an editor view:
+TortoiseSVN and Beyond Compare in an editor view:
 
-![Tortoise SVN and Beyond Compare in an editor view](https://github.com/ContextQuickie/ContextQuickie/blob/master/Images/TortoiseSvnAndBeyondCompareInEditor.png)
+![TortoiseSVN and Beyond Compare in an editor view](https://github.com/ContextQuickie/ContextQuickie/blob/master/Images/TortoiseSvnAndBeyondCompareInEditor.png)


### PR DESCRIPTION
TortoiseGit and TortoiseSVN don't use a blank in their name.